### PR TITLE
feat: PB-126495 Add designerReadOnly property to Document

### DIFF
--- a/sdk/src/main/java/com/silanis/esl/api/model/Document.java
+++ b/sdk/src/main/java/com/silanis/esl/api/model/Document.java
@@ -48,6 +48,8 @@ public class Document extends Entity
     @JsonIgnore
     public static final String FIELD_TAGGED = "tagged";
     @JsonIgnore
+    public static final String FIELD_DESIGNER_READ_ONLY = "designerReadOnly";
+    @JsonIgnore
     public static final String FIELD_EXTERNAL_SIGNED = "externalSigned";
     @JsonIgnore
     public static final String FIELD_BASE64_CONTENT = "base64Content";
@@ -71,6 +73,7 @@ public class Document extends Entity
     protected String _signedHash;
     protected String _signerVerificationToken;
     protected Boolean _tagged = false;
+    protected Boolean _designerReadOnly = false;
     protected Boolean _externalSigned = false;
     protected String _base64Content;
 
@@ -442,6 +445,30 @@ public class Document extends Entity
     @JsonIgnore
     public boolean evalTagged() {
         return _tagged == null ? false : _tagged.booleanValue();
+    }
+
+    public Document setDesignerReadOnly(Boolean value) {
+        SchemaSanitizer.throwOnNull(FIELD_DESIGNER_READ_ONLY, value);
+        this._designerReadOnly = value;
+        setDirty(FIELD_DESIGNER_READ_ONLY);
+        return this;
+    }
+
+    @JsonIgnore
+    public Document safeSetDesignerReadOnly(Boolean value) {
+        if (value != null) {
+            this.setDesignerReadOnly(value);
+        }
+        return this;
+    }
+
+    public Boolean getDesignerReadOnly() {
+        return _designerReadOnly;
+    }
+
+    @JsonIgnore
+    public boolean evalDesignerReadOnly() {
+        return _designerReadOnly == null ? false : _designerReadOnly.booleanValue();
     }
 
     public Boolean isExternalSigned() { return _externalSigned; }

--- a/sdk/src/main/java/com/silanis/esl/sdk/Document.java
+++ b/sdk/src/main/java/com/silanis/esl/sdk/Document.java
@@ -24,6 +24,7 @@ public class Document implements Serializable {
     private int numberOfPages;
     private boolean extract;
     private Boolean tagged;
+    private Boolean designerReadOnly;
     private Set<String> extractionTypes = Sets.newHashSet();
     private DocumentId id;
     private List<Field> injectedFields = new ArrayList<Field>();
@@ -155,6 +156,14 @@ public class Document implements Serializable {
 
     public void setTagged(boolean tagged) {
         this.tagged = tagged;
+    }
+
+    public Boolean isDesignerReadOnly() {
+        return designerReadOnly;
+    }
+
+    public void setDesignerReadOnly(boolean designerReadOnly) {
+        this.designerReadOnly = designerReadOnly;
     }
 
     public Set<String> getExtractionTypes() {

--- a/sdk/src/main/java/com/silanis/esl/sdk/builder/DocumentBuilder.java
+++ b/sdk/src/main/java/com/silanis/esl/sdk/builder/DocumentBuilder.java
@@ -32,6 +32,7 @@ public class DocumentBuilder {
     private External external;
     private Map<String, Object> data = new LinkedHashMap<String, Object>();
     private String base64Content;
+    private Boolean designerReadOnly;
 
     public DocumentBuilder() {
         this.name = DEFAULT_NAME;
@@ -165,6 +166,9 @@ public class DocumentBuilder {
         if (base64Content != null) {
             document.setBase64Content(base64Content);
         }
+        if (designerReadOnly != null) {
+            document.setDesignerReadOnly(designerReadOnly);
+        }
 
         return document;
     }
@@ -278,6 +282,17 @@ public class DocumentBuilder {
      */
     public DocumentBuilder fromBase64Content(String base64Content) {
         this.base64Content = base64Content;
+        return this;
+    }
+
+    /**
+     * Set whether this document is read only in the designer
+     *
+     * @param designerReadOnly
+     * @return the document builder itself
+     */
+    public DocumentBuilder withDesignerReadOnly(boolean designerReadOnly) {
+        this.designerReadOnly = designerReadOnly;
         return this;
     }
 }

--- a/sdk/src/main/java/com/silanis/esl/sdk/internal/converter/DocumentConverter.java
+++ b/sdk/src/main/java/com/silanis/esl/sdk/internal/converter/DocumentConverter.java
@@ -91,6 +91,10 @@ public class DocumentConverter {
             document.setTagged(apiDocument.getTagged());
         }
 
+        if ( apiDocument.getDesignerReadOnly() != null ) {
+            document.setDesignerReadOnly(apiDocument.getDesignerReadOnly());
+        }
+
         if ( apiDocument.isExternalSigned() != null ) {
             document.setExternalSigned(apiDocument.isExternalSigned());
         }
@@ -124,6 +128,7 @@ public class DocumentConverter {
         }
         result.safeSetDescription(sdkDocument.getDescription());
         result.safeSetTagged(sdkDocument.isTagged());
+        result.safeSetDesignerReadOnly(sdkDocument.isDesignerReadOnly());
         result.safeSetExternalSigned(sdkDocument.isExternalSigned());
         result.safeSetBase64Content(sdkDocument.getBase64Content());
 

--- a/sdk/src/test/java/com/silanis/esl/sdk/internal/converter/DocumentConverterTest.java
+++ b/sdk/src/test/java/com/silanis/esl/sdk/internal/converter/DocumentConverterTest.java
@@ -180,6 +180,30 @@ public class DocumentConverterTest {
         assertThat("API document Base64 content is null", apiDocument1.getBase64Content(), notNullValue());
     }
 
+    @Test
+    public void convertSDKtoAPIWithDesignerReadOnly() {
+        documentInputStream = this.getClass().getClassLoader().getResourceAsStream("document.pdf");
+        sdkDocument1 = newDocumentWithName("sdkDocument")
+                .fromStream(documentInputStream, DocumentType.PDF)
+                .withId("sdkDocumentId")
+                .withDesignerReadOnly(true)
+                .build();
+        com.silanis.esl.api.model.Package apiPackage = new com.silanis.esl.api.model.Package();
+
+        apiDocument1 = new DocumentConverter(sdkDocument1).toAPIDocument(apiPackage);
+
+        assertThat("API document DesignerReadOnly was not correctly set", apiDocument1.getDesignerReadOnly(), is(true));
+    }
+
+    @Test
+    public void convertAPItoSDKWithDesignerReadOnly() {
+        apiDocument1 = createTypicalAPIDocument().setDesignerReadOnly(true);
+
+        sdkDocument1 = new DocumentConverter(apiDocument1, apiPackage).toSDKDocument();
+
+        assertThat("SDK document DesignerReadOnly was not correctly set", sdkDocument1.isDesignerReadOnly(), is(true));
+    }
+
     private com.silanis.esl.sdk.Document createDocumentWithData(final String name, final String value) {
         com.silanis.esl.sdk.Document sdkDocument;
         documentInputStream = this.getClass().getClassLoader()


### PR DESCRIPTION
## What

Adds the new `designerReadOnly` Boolean property to Document, matching the backend API contract.

- `api/model/Document.java` — field with setter/safeSet/getter/eval and dirty-field tracking
- `sdk/Document.java` — public domain model accessors
- `DocumentConverter.java` — mapped in both directions
- `DocumentBuilder.java` — new `withDesignerReadOnly(boolean)` fluent method (property is only sent when explicitly set)

## Testing

- Two new round-trip tests in `DocumentConverterTest` (SDK→API and API→SDK); all 16 tests pass.

A matching change is being submitted to the .NET SDK.

Generated with Claude Code